### PR TITLE
Add React client pages for authenticated API usage

### DIFF
--- a/boilerplate-client/package-lock.json
+++ b/boilerplate-client/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -2872,6 +2873,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -12859,6 +12869,38 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/boilerplate-client/package.json
+++ b/boilerplate-client/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/boilerplate-client/src/App.js
+++ b/boilerplate-client/src/App.js
@@ -1,0 +1,31 @@
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { AuthProvider, RequireAuth } from './AuthContext';
+import Login from './pages/Login';
+import Signup from './pages/Signup';
+import Groups from './pages/Groups';
+import Permissions from './pages/Permissions';
+import UserPermissions from './pages/UserPermissions';
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <BrowserRouter>
+        <nav>
+          <Link to="/login">Login</Link> |{' '}
+          <Link to="/signup">Signup</Link> |{' '}
+          <Link to="/groups">Groups</Link> |{' '}
+          <Link to="/permissions">Permissions</Link> |{' '}
+          <Link to="/user-permissions">User Permissions</Link>
+        </nav>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/groups" element={<RequireAuth><Groups /></RequireAuth>} />
+          <Route path="/permissions" element={<RequireAuth><Permissions /></RequireAuth>} />
+          <Route path="/user-permissions" element={<RequireAuth><UserPermissions /></RequireAuth>} />
+          <Route path="*" element={<Login />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
+  );
+}

--- a/boilerplate-client/src/App.test.js
+++ b/boilerplate-client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByRole('link', { name: /login/i });
   expect(linkElement).toBeInTheDocument();
 });

--- a/boilerplate-client/src/AuthContext.js
+++ b/boilerplate-client/src/AuthContext.js
@@ -1,0 +1,37 @@
+import { createContext, useContext, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  const login = (newToken) => {
+    setToken(newToken);
+    localStorage.setItem('token', newToken);
+  };
+
+  const logout = () => {
+    setToken(null);
+    localStorage.removeItem('token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+export function RequireAuth({ children }) {
+  const { token } = useAuth();
+  const location = useLocation();
+  if (!token) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+  return children;
+}

--- a/boilerplate-client/src/api.js
+++ b/boilerplate-client/src/api.js
@@ -1,0 +1,10 @@
+export async function apiFetch(token, url, options = {}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {})
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return fetch(url, { ...options, headers });
+}

--- a/boilerplate-client/src/index.js
+++ b/boilerplate-client/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/boilerplate-client/src/pages/Groups.js
+++ b/boilerplate-client/src/pages/Groups.js
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { useAuth } from '../AuthContext';
+import { apiFetch } from '../api';
+
+export default function Groups() {
+  const { token } = useAuth();
+  const [output, setOutput] = useState(null);
+  const [groupId, setGroupId] = useState('');
+  const [userId, setUserId] = useState('');
+  const [permissionId, setPermissionId] = useState('');
+  const [name, setName] = useState('');
+
+  const handle = async (method, url, body) => {
+    const res = await apiFetch(token, url, {
+      method,
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const data = await res.json().catch(() => null);
+    setOutput(data);
+  };
+
+  return (
+    <div>
+      <h2>Groups</h2>
+
+      <section>
+        <h3>Create Group</h3>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
+        <button onClick={() => handle('POST', '/api/auth/groups', { name })}>Create</button>
+      </section>
+
+      <section>
+        <h3>Get All Groups</h3>
+        <button onClick={() => handle('GET', '/api/auth/groups')}>Get Groups</button>
+      </section>
+
+      <section>
+        <h3>Get Group By Id</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <button onClick={() => handle('GET', `/api/auth/groups/${groupId}`)}>Get Group</button>
+      </section>
+
+      <section>
+        <h3>Update Group</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="New Name" />
+        <button onClick={() => handle('PUT', `/api/auth/groups/${groupId}`, { name })}>Update</button>
+      </section>
+
+      <section>
+        <h3>Delete Group</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <button onClick={() => handle('DELETE', `/api/auth/groups/${groupId}`)}>Delete</button>
+      </section>
+
+      <section>
+        <h3>Add User To Group</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User Id" />
+        <button onClick={() => handle('POST', `/api/auth/groups/${groupId}/users/${userId}`)}>Add</button>
+      </section>
+
+      <section>
+        <h3>Remove User From Group</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User Id" />
+        <button onClick={() => handle('DELETE', `/api/auth/groups/${groupId}/users/${userId}`)}>Remove</button>
+      </section>
+
+      <section>
+        <h3>Assign Permission To Group</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <input value={permissionId} onChange={e => setPermissionId(e.target.value)} placeholder="Permission Id" />
+        <button onClick={() => handle('POST', `/api/auth/groups/${groupId}/permissions`, { permissionId })}>Assign</button>
+      </section>
+
+      <section>
+        <h3>Remove Group Permission</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <input value={permissionId} onChange={e => setPermissionId(e.target.value)} placeholder="Permission Id" />
+        <button onClick={() => handle('DELETE', `/api/auth/groups/${groupId}/permissions/${permissionId}`)}>Remove</button>
+      </section>
+
+      <section>
+        <h3>Get Group Permissions</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <button onClick={() => handle('GET', `/api/auth/groups/${groupId}/permissions`)}>Get Permissions</button>
+      </section>
+
+      <section>
+        <h3>Get Group Users</h3>
+        <input value={groupId} onChange={e => setGroupId(e.target.value)} placeholder="Group Id" />
+        <button onClick={() => handle('GET', `/api/auth/groups/${groupId}/users`)}>Get Users</button>
+      </section>
+
+      <pre>{output && JSON.stringify(output, null, 2)}</pre>
+    </div>
+  );
+}

--- a/boilerplate-client/src/pages/Login.js
+++ b/boilerplate-client/src/pages/Login.js
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+import { apiFetch } from '../api';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    const res = await apiFetch(null, '/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      login(data.token);
+      navigate('/groups');
+    } else {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Login</button>
+      </form>
+      {error && <p>{error}</p>}
+    </div>
+  );
+}

--- a/boilerplate-client/src/pages/Permissions.js
+++ b/boilerplate-client/src/pages/Permissions.js
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useAuth } from '../AuthContext';
+import { apiFetch } from '../api';
+
+export default function Permissions() {
+  const { token } = useAuth();
+  const [output, setOutput] = useState(null);
+  const [permissionId, setPermissionId] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [permission, setPermission] = useState('');
+
+  const handle = async (method, url, body) => {
+    const res = await apiFetch(token, url, {
+      method,
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const data = await res.json().catch(() => null);
+    setOutput(data);
+  };
+
+  return (
+    <div>
+      <h2>Permissions</h2>
+
+      <section>
+        <h3>Create Permission</h3>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" />
+        <button onClick={() => handle('POST', '/api/auth/permissions', { name })}>Create</button>
+      </section>
+
+      <section>
+        <h3>Get All Permissions</h3>
+        <button onClick={() => handle('GET', '/api/auth/permissions')}>Get All</button>
+      </section>
+
+      <section>
+        <h3>Get Permission By Id</h3>
+        <input value={permissionId} onChange={e => setPermissionId(e.target.value)} placeholder="Permission Id" />
+        <button onClick={() => handle('GET', `/api/auth/permissions/${permissionId}`)}>Get</button>
+      </section>
+
+      <section>
+        <h3>Update Permission</h3>
+        <input value={permissionId} onChange={e => setPermissionId(e.target.value)} placeholder="Permission Id" />
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="New Name" />
+        <button onClick={() => handle('PUT', `/api/auth/permissions/${permissionId}`, { newName: name })}>Update</button>
+      </section>
+
+      <section>
+        <h3>Delete Permission</h3>
+        <input value={permissionId} onChange={e => setPermissionId(e.target.value)} placeholder="Permission Id" />
+        <button onClick={() => handle('DELETE', `/api/auth/permissions/${permissionId}`)}>Delete</button>
+      </section>
+
+      <section>
+        <h3>Assign Permission To User</h3>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="User Email" />
+        <input value={permission} onChange={e => setPermission(e.target.value)} placeholder="Permission" />
+        <button onClick={() => handle('POST', '/api/auth/permissions/assign', { email, permission })}>Assign</button>
+      </section>
+
+      <pre>{output && JSON.stringify(output, null, 2)}</pre>
+    </div>
+  );
+}

--- a/boilerplate-client/src/pages/Signup.js
+++ b/boilerplate-client/src/pages/Signup.js
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { apiFetch } from '../api';
+
+export default function Signup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage('');
+    const res = await apiFetch(null, '/api/auth/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      setMessage('User created');
+      navigate('/login');
+    } else {
+      setMessage('Signup failed');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Signup</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button type="submit">Signup</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/boilerplate-client/src/pages/UserPermissions.js
+++ b/boilerplate-client/src/pages/UserPermissions.js
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { useAuth } from '../AuthContext';
+import { apiFetch } from '../api';
+
+export default function UserPermissions() {
+  const { token } = useAuth();
+  const [output, setOutput] = useState(null);
+  const [userId, setUserId] = useState('');
+  const [permissionId, setPermissionId] = useState('');
+  const [oldPermissionId, setOldPermissionId] = useState('');
+  const [newPermissionId, setNewPermissionId] = useState('');
+
+  const handle = async (method, url, body) => {
+    const res = await apiFetch(token, url, {
+      method,
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const data = await res.json().catch(() => null);
+    setOutput(data);
+  };
+
+  return (
+    <div>
+      <h2>User Permissions</h2>
+
+      <section>
+        <h3>Assign Permission To User</h3>
+        <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User Id" />
+        <input value={permissionId} onChange={e => setPermissionId(e.target.value)} placeholder="Permission Id" />
+        <button
+          onClick={() =>
+            handle('POST', '/api/user-permissions/assign', { userId, permissionId })
+          }
+        >
+          Assign
+        </button>
+      </section>
+
+      <section>
+        <h3>Get User Permissions</h3>
+        <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User Id" />
+        <button onClick={() => handle('GET', `/api/users/${userId}/permissions`)}>
+          Get Permissions
+        </button>
+      </section>
+
+      <section>
+        <h3>Get User Effective Permissions</h3>
+        <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User Id" />
+        <button onClick={() => handle('GET', `/api/auth/users/${userId}/effective-permissions`)}>
+          Get Effective
+        </button>
+      </section>
+
+      <section>
+        <h3>Remove User Permission</h3>
+        <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User Id" />
+        <input value={permissionId} onChange={e => setPermissionId(e.target.value)} placeholder="Permission Id" />
+        <button
+          onClick={() =>
+            handle('DELETE', `/api/auth/users/${userId}/permissions/${permissionId}`)
+          }
+        >
+          Remove
+        </button>
+      </section>
+
+      <section>
+        <h3>Update User Permission</h3>
+        <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User Id" />
+        <input
+          value={oldPermissionId}
+          onChange={e => setOldPermissionId(e.target.value)}
+          placeholder="Old Permission Id"
+        />
+        <input
+          value={newPermissionId}
+          onChange={e => setNewPermissionId(e.target.value)}
+          placeholder="New Permission Id"
+        />
+        <button
+          onClick={() =>
+            handle('PUT', `/api/auth/users/${userId}/permissions`, {
+              oldPermissionId,
+              newPermissionId
+            })
+          }
+        >
+          Update
+        </button>
+      </section>
+
+      <pre>{output && JSON.stringify(output, null, 2)}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add React auth context with login/logout and route guard
- create login and signup pages
- add pages to exercise group, permission, and user permission endpoints

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b8a06a247c832b90eb88e852b7aef0