### PR TITLE
feat: allow authenticated user to create schoolhouse

### DIFF
--- a/Boilerplate.Api/Controllers/auth/LoginEndpoint.cs
+++ b/Boilerplate.Api/Controllers/auth/LoginEndpoint.cs
@@ -42,11 +42,11 @@ public class LoginEndpoint : IEndpoint
                 expires: DateTime.UtcNow.AddHours(1),
                 signingCredentials: creds);
 
-            return Results.Ok(new { token = new JwtSecurityTokenHandler().WriteToken(token) })
-                .WithName("Login")
-                .WithTags("Auth")
-                .WithOpenApi();
-        });
+            return Results.Ok(new { token = new JwtSecurityTokenHandler().WriteToken(token) });
+        })
+        .WithName("Login")
+        .WithTags("Auth")
+        .WithOpenApi();
     }
 }
 

--- a/Boilerplate.Api/Controllers/schoolhouses/CreateSchoolhouseEndpoint.cs
+++ b/Boilerplate.Api/Controllers/schoolhouses/CreateSchoolhouseEndpoint.cs
@@ -1,0 +1,85 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Boilerplate.Api.Schoolhouses;
+
+public class CreateSchoolhouseEndpoint : IEndpoint
+{
+    public void Map(IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/schoolhouses", async (
+            ClaimsPrincipal claims,
+            [FromBody] CreateSchoolhouseRequest body,
+            AppDbContext db,
+            UserManager<AppUser> userManager,
+            RoleManager<Group> roleManager) =>
+        {
+            var owner = await userManager.GetUserAsync(claims);
+            if (owner == null) return Results.Unauthorized();
+
+            if (await db.Schoolhouses.AnyAsync(s => s.Subdomain == body.Subdomain))
+                return Results.BadRequest("Subdomain already in use.");
+
+            if (await db.Schoolhouses.AnyAsync(s => s.Name == body.Name))
+                return Results.BadRequest("Name already in use.");
+
+            var school = new Schoolhouse
+            {
+                Id = Guid.NewGuid(),
+                OwnerId = owner.Id,
+                Name = body.Name,
+                Subdomain = body.Subdomain,
+                Description = body.Description ?? string.Empty,
+                Tagline = body.Tagline ?? string.Empty,
+                Location = body.Location ?? string.Empty,
+                LogoUrl = body.LogoUrl ?? string.Empty,
+                BannerUrl = body.BannerUrl ?? string.Empty,
+                ThemeColor = body.ThemeColor ?? string.Empty
+            };
+
+            db.Schoolhouses.Add(school);
+            await db.SaveChangesAsync();
+
+            await EnsureDefaultRolesAsync(roleManager);
+            await userManager.AddToRoleAsync(owner, "Schoolmaster");
+
+            // TODO: Generate welcome packet and schedule onboarding emails.
+
+            return Results.Created($"/api/schoolhouses/{school.Id}", school);
+        })
+        .WithName("CreateSchoolhouse")
+        .WithTags("Schoolhouses")
+        .WithOpenApi()
+        .RequireAuthorization();
+    }
+
+    private static async Task EnsureDefaultRolesAsync(RoleManager<Group> roleManager)
+    {
+        var roles = new[] { "Schoolmaster", "Dean", "Instructor", "Apprentice" };
+        foreach (var role in roles)
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+            {
+                await roleManager.CreateAsync(new Group
+                {
+                    Name = role,
+                    NormalizedName = role.ToUpper()
+                });
+            }
+        }
+    }
+}
+
+public class CreateSchoolhouseRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Subdomain { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Tagline { get; set; }
+    public string? Location { get; set; }
+    public string? LogoUrl { get; set; }
+    public string? BannerUrl { get; set; }
+    public string? ThemeColor { get; set; }
+}

--- a/Boilerplate.Api/Data/AppDbContext.cs
+++ b/Boilerplate.Api/Data/AppDbContext.cs
@@ -9,6 +9,7 @@ public class AppDbContext : IdentityDbContext<AppUser, IdentityRole<Guid>, Guid>
     public DbSet<GroupPermission> GroupPermissions { get; set; }
     public DbSet<UserGroup> UserGroups { get; set; }
     public DbSet<ForensicLog> ForensicLogs { get; set; }
+    public DbSet<Schoolhouse> Schoolhouses { get; set; }
 
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
@@ -18,5 +19,19 @@ public class AppDbContext : IdentityDbContext<AppUser, IdentityRole<Guid>, Guid>
 
         builder.Entity<UserGroup>().HasKey(ug => new { ug.UserId, ug.GroupId });
         builder.Entity<GroupPermission>().HasKey(gp => new { gp.GroupId, gp.PermissionId });
+
+        builder.Entity<Schoolhouse>()
+            .HasIndex(s => s.Name)
+            .IsUnique();
+
+        builder.Entity<Schoolhouse>()
+            .HasIndex(s => s.Subdomain)
+            .IsUnique();
+
+        builder.Entity<Schoolhouse>()
+            .HasOne(s => s.Owner)
+            .WithMany()
+            .HasForeignKey(s => s.OwnerId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/Boilerplate.Api/Migrations/20250903202632_CreateSchoolhouses.Designer.cs
+++ b/Boilerplate.Api/Migrations/20250903202632_CreateSchoolhouses.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Boilerplate.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250903202632_CreateSchoolhouses")]
+    partial class CreateSchoolhouses
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Boilerplate.Api/Migrations/20250903202632_CreateSchoolhouses.cs
+++ b/Boilerplate.Api/Migrations/20250903202632_CreateSchoolhouses.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Boilerplate.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateSchoolhouses : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Discriminator",
+                table: "AspNetRoles",
+                type: "character varying(21)",
+                maxLength: 21,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "Schoolhouses",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Subdomain = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    Tagline = table.Column<string>(type: "text", nullable: false),
+                    Location = table.Column<string>(type: "text", nullable: false),
+                    LogoUrl = table.Column<string>(type: "text", nullable: false),
+                    BannerUrl = table.Column<string>(type: "text", nullable: false),
+                    ThemeColor = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Schoolhouses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Schoolhouses_AspNetUsers_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schoolhouses_Name",
+                table: "Schoolhouses",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schoolhouses_OwnerId",
+                table: "Schoolhouses",
+                column: "OwnerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schoolhouses_Subdomain",
+                table: "Schoolhouses",
+                column: "Subdomain",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Schoolhouses");
+
+            migrationBuilder.DropColumn(
+                name: "Discriminator",
+                table: "AspNetRoles");
+        }
+    }
+}

--- a/Boilerplate.Api/Models/Schoolhouse.cs
+++ b/Boilerplate.Api/Models/Schoolhouse.cs
@@ -1,0 +1,17 @@
+using System;
+
+public class Schoolhouse
+{
+    public Guid Id { get; set; }
+    public Guid OwnerId { get; set; }
+    public AppUser? Owner { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Subdomain { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Tagline { get; set; } = string.Empty;
+    public string Location { get; set; } = string.Empty;
+    public string LogoUrl { get; set; } = string.Empty;
+    public string BannerUrl { get; set; } = string.Empty;
+    public string ThemeColor { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}


### PR DESCRIPTION
## Summary
- add Schoolhouse model and persistence with unique subdomain and name
- introduce endpoint for authenticated users to create schoolhouses and seed default roles
- adjust login endpoint to attach metadata outside handler

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a3addd88832b85df0c4a3433476b